### PR TITLE
Fixes v-bind not working on an eloquentjs object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@megawubs/eloquentjs",
-  "version": "0.0.3-beta",
+  "version": "0.0.32-beta",
   "description": "An active record like approach to consuming an API, inspired by Laravel's Eloquent",
   "main": "index.js",
   "directories": {

--- a/source/map.js
+++ b/source/map.js
@@ -13,6 +13,7 @@ function mapResponseToModel(response, bluePrint) {
   for (var key in response) {
     if (response.hasOwnProperty(key)) {
       model.properties[key] = response[key];
+      model[key] = response[key];
     }
   }
   return model;

--- a/source/proxyfy.js
+++ b/source/proxyfy.js
@@ -22,11 +22,12 @@ export class ModelProxy {
         if (self.canAccessProperty(name)) return target[name];
         if (name === 'proxify') return receiver;
 
-        return target.properties[name];
+        return target[name];
       },
       set: function (target, name, value) {
         target.hasChanged = true;
-        target.properties[name] = value;
+        target['properties'][name] = value;
+        target[name] = value;
         return true;
       }
     });


### PR DESCRIPTION
Vue is unable to bind on a not-existing property. That's why properties are now also set on the target as on the properties property trough `proxyfy`. 